### PR TITLE
fix: Add capacity api #7

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -124,6 +124,28 @@ impl<T> Graph<T> {
         self.inbound_table.reserve(additional);
     }
 
+    /// Shrinks the capacity of the Graph as much as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator may still inform the
+    /// vector that there is space for a few more elements.
+    /// ## Example
+    /// ```rust
+    /// use graphlib::Graph;
+    /// let mut graph: Graph<usize> = Graph::with_capacity(5);
+    ///
+    /// assert_eq!(graph.capacity(), 5);
+    ///
+    /// graph.shrink_to_fit();
+    /// assert_eq!(graph.capacity(), 0);
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        self.edges.shrink_to_fit();
+        self.roots.shrink_to_fit();
+        self.vertices.shrink_to_fit();
+        self.outbound_table.shrink_to_fit();
+        self.inbound_table.shrink_to_fit();
+    }
+
     /// Adds a new vertex to the graph and returns the id
     /// of the added vertex.
     ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -32,6 +32,25 @@ impl<T> Graph<T> {
         }
     }
 
+    /// Creates a Graph with the given capacity
+    /// *note: you can push more data into the graph but it will reallocate itself*
+    ///
+    /// ## Example
+    /// ```rust
+    /// use graphlib::Graph;
+    ///
+    /// let mut graph: Graph<usize> = Graph::with_capacity(5);
+    /// ```
+    pub fn with_capacity(capacity: usize) -> Graph<T> {
+        Graph {
+            vertices: HashMap::with_capacity(capacity),
+            edges: Vec::with_capacity(capacity),
+            roots: Vec::with_capacity(capacity),
+            inbound_table: HashMap::with_capacity(capacity),
+            outbound_table: HashMap::with_capacity(capacity),
+        }
+    }
+
     /// Adds a new vertex to the graph and returns the id
     /// of the added vertex.
     ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,7 +2,6 @@
 
 use crate::edge::Edge;
 use crate::iterators::{Bfs, Dfs, VertexIter};
-use crate::macros;
 use crate::vertex_id::VertexId;
 use hashbrown::HashMap;
 use std::sync::Arc;
@@ -68,33 +67,6 @@ impl<T> Graph<T> {
             self.roots.capacity(),
             self.inbound_table.capacity(),
             self.outbound_table.capacity()
-        )
-    }
-
-    /// return a verbose number of elements the Graph can hold without reallocating in the following order
-    ///
-    /// `(vertices, edges, roots, inbound_table, outbound_table)`
-    ///
-    /// ## Example
-    /// ```rust
-    /// use graphlib::Graph;
-    ///
-    /// let mut graph: Graph<usize> = Graph::with_capacity(5);
-    ///
-    /// let c = graph.capacity_v();
-    /// assert!(c.0 > 5); // hashbrown [implementation](https://docs.rs/hashbrown/0.1.8/hashbrown/struct.HashMap.html#method.capacity)
-    /// assert_eq!(5, c.1);
-    /// assert_eq!(5, c.2);
-    /// assert!(c.3 > 5);
-    /// assert!(c.4 > 5);
-    /// ```
-    pub fn capacity_v(&self) -> (usize, usize, usize, usize, usize) {
-        (
-            self.vertices.capacity(),
-            self.edges.capacity(),
-            self.roots.capacity(),
-            self.inbound_table.capacity(),
-            self.outbound_table.capacity(),
         )
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -102,6 +102,28 @@ impl<T> Graph<T> {
         )
     }
 
+    /// Reserves capacity for at least additional more elements to be inserted in the given
+    /// `Graph`. After calling reserve, capacity will be greater than or equal to `self.len() + additional`.
+    ///
+    /// ## Example
+    /// ```rust
+    /// use graphlib::Graph;
+    ///
+    /// let mut graph: Graph<usize> = Graph::with_capacity(5);
+    ///
+    /// assert_eq!(graph.capacity(), 5);
+    ///
+    /// graph.reserve(10);
+    /// assert_eq!(graph.capacity(), 10);
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.edges.reserve(additional);
+        self.roots.reserve(additional);
+        self.vertices.reserve(additional);
+        self.outbound_table.reserve(additional);
+        self.inbound_table.reserve(additional);
+    }
+
     /// Adds a new vertex to the graph and returns the id
     /// of the added vertex.
     ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -44,7 +44,7 @@ impl<T> Graph<T> {
     pub fn with_capacity(capacity: usize) -> Graph<T> {
         Graph {
             vertices: HashMap::with_capacity(capacity),
-            edges: Vec::with_capacity(capacity),
+            edges: Vec::with_capacity(usize::pow(capacity, 2)),
             roots: Vec::with_capacity(capacity),
             inbound_table: HashMap::with_capacity(capacity),
             outbound_table: HashMap::with_capacity(capacity),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,14 +2,10 @@
 
 use crate::edge::Edge;
 use crate::iterators::{Bfs, Dfs, VertexIter};
+use crate::macros;
 use crate::vertex_id::VertexId;
 use hashbrown::HashMap;
 use std::sync::Arc;
-
-macro_rules! min {
-    ($x: expr) => ($x);
-    ($x: expr, $($z: expr),+) => (::std::cmp::min($x, min!($($z),*)));
-}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GraphErr {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,6 +6,11 @@ use crate::vertex_id::VertexId;
 use hashbrown::HashMap;
 use std::sync::Arc;
 
+macro_rules! min {
+    ($x: expr) => ($x);
+    ($x: expr, $($z: expr),+) => (::std::cmp::min($x, min!($($z),*)));
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum GraphErr {
     NoSuchVertex,
@@ -32,7 +37,7 @@ impl<T> Graph<T> {
         }
     }
 
-    /// Creates a Graph with the given capacity
+    /// Creates a Graph with the given capacity.
     /// *note: you can push more data into the graph but it will reallocate itself*
     ///
     /// ## Example
@@ -49,6 +54,52 @@ impl<T> Graph<T> {
             inbound_table: HashMap::with_capacity(capacity),
             outbound_table: HashMap::with_capacity(capacity),
         }
+    }
+
+    /// Returns the minimum number of elements the Graph can hold without reallocating.
+    /// ## Example
+    /// ```rust
+    /// use graphlib::Graph;
+    ///
+    /// let mut graph: Graph<usize> = Graph::with_capacity(5);
+    ///
+    /// assert_eq!(graph.capacity(), 5);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        min!(
+            self.vertices.capacity(),
+            self.edges.capacity(),
+            self.roots.capacity(),
+            self.inbound_table.capacity(),
+            self.outbound_table.capacity()
+        )
+    }
+
+    /// return a verbose number of elements the Graph can hold without reallocating in the following order
+    ///
+    /// `(vertices, edges, roots, inbound_table, outbound_table)`
+    ///
+    /// ## Example
+    /// ```rust
+    /// use graphlib::Graph;
+    ///
+    /// let mut graph: Graph<usize> = Graph::with_capacity(5);
+    ///
+    /// let c = graph.capacity_v();
+    /// assert!(c.0 > 5); // hashbrown [implementation](https://docs.rs/hashbrown/0.1.8/hashbrown/struct.HashMap.html#method.capacity)
+    /// assert_eq!(5, c.1);
+    /// assert_eq!(5, c.2);
+    /// assert!(c.3 > 5);
+    /// assert!(c.4 > 5);
+    /// ```
+    pub fn capacity_v(&self) -> (usize, usize, usize, usize, usize) {
+        (
+            self.vertices.capacity(),
+            self.edges.capacity(),
+            self.roots.capacity(),
+            self.inbound_table.capacity(),
+            self.outbound_table.capacity(),
+        )
     }
 
     /// Adds a new vertex to the graph and returns the id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 // Copyright 2019 Octavian Oncescu
 
-//! # Graphlib 
-//! Graphlib is a simple and powerful rust library for the graph data-structure. 
+//! # Graphlib
+//! Graphlib is a simple and powerful rust library for the graph data-structure.
 //!
 //! ---
 //!
-//! This library attempts to provide a generic api for building, mutating and iterating over graphs that is similar to that of other data-structures in rust i.e. `Vec`, `HashMap`, `VecDeque`, etc. 
-//! 
+//! This library attempts to provide a generic api for building, mutating and iterating over graphs that is similar to that of other data-structures in rust i.e. `Vec`, `HashMap`, `VecDeque`, etc.
+//!
 //! ### Usage
 //! ```rust
 //! use graphlib::Graph;
@@ -35,6 +35,8 @@
 //! ```
 
 mod edge;
+#[macro_use]
+mod macros;
 mod graph;
 pub mod iterators;
 mod vertex_id;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,6 @@
+/// macro to find minimum of a number
+#[macro_export]
+macro_rules! min {
+    ($x: expr) => ($x);
+    ($x: expr, $($z: expr),+) => (::std::cmp::min($x, min!($($z),*)));
+}


### PR DESCRIPTION
fixex #7, though a few points -

1. Cannot implement `Graph::shrink_to()` in stable rust (currently only possible in nightly)
2. Cannot implement `Graph::reserve_exact()` as [Hashbrown](https://docs.rs/hashbrown/0.1.8/hashbrown/struct.HashMap.html#method.reserve) cannot implement `reserve_exact`

Was able to complete all others with complete documentation and example

I also added `capacity_v()` to give more verbose result about `Graph` capacity complete with example and documentation