### PR TITLE
Address Issue #9

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -522,9 +522,9 @@ impl<T> Graph<T> {
     /// graph.add_edge(&v3, &v4).unwrap();
     ///
     /// assert!(!graph.is_cyclic());
-    ///
+    /// 
     /// graph.add_edge(&v3, &v1);
-    ///
+    /// 
     /// assert!(graph.is_cyclic());
     /// ```
     pub fn is_cyclic(&self) -> bool {

--- a/src/iterators/dfs.rs
+++ b/src/iterators/dfs.rs
@@ -60,23 +60,26 @@ impl<'a, T> Dfs<'a, T> {
 
         //Calculate the answer.
         let cyclic = (|| {
+            //If there are no roots then there must be cycles.
+            if self.iterable.roots_count() == 0 { return true }
+
             //The vertices pending processing.
             let mut pending_stack = Vec::new();
             //The ids of all the visited vertices.
             let mut visited = HashSet::new();
+            //This is all the vertices which have been visited by the current root.
+            let mut root_visited = HashSet::new();
             
             //Iterate all roots to check all paths.
             for root in self.iterable.roots() {
-                //This indicates that we have not encountered an already visited vertex
-                let mut root_visited = HashSet::new();
-
                 pending_stack.push(*root);
+
                 //Process all pending vertices.
                 while let Some(v) = pending_stack.pop() {
-                    //If true This path has found a cycle.
+                    //If true there is a cycle.
                     if !root_visited.insert(v) { return true }
-                    
-                    //Add all of its outbound neibours to be processed.
+
+                    //Add all of this vertexes outbound neibours to be processed.
                     for &v in self.iterable.out_neighbors(&v) {
                         //If this vertex exists in visited then we have already checked it for cycles.
                         if !visited.contains(&v) {
@@ -85,8 +88,8 @@ impl<'a, T> Dfs<'a, T> {
                     }
                 }
 
-                //Move all of the vertices visited in this check into the previously visited pool.
-                visited.extend(root_visited);
+                //Forget all the vertexes visited from this root specifically.
+                visited.extend(root_visited.drain());
             }
 
             false

--- a/src/iterators/vertices.rs
+++ b/src/iterators/vertices.rs
@@ -1,34 +1,20 @@
 // Copyright 2019 Octavian Oncescu
 
 use crate::vertex_id::VertexId;
+use std::fmt::Debug;
 
+pub(crate) trait MergedTrait<'a,>: Iterator<Item = &'a VertexId> + Debug {}
+
+impl<'a, T,> MergedTrait<'a,> for T
+    where T: Iterator<Item = &'a VertexId> + Debug {}
+
+/// Generic Vertex Iterator.
 #[derive(Debug)]
-/// Generic Vertex Iterator
-pub struct VertexIter<'a> {
-    current: usize,
-    iterable: Vec<&'a VertexId>,
-}
-
-impl<'a> VertexIter<'a> {
-    pub fn new(neighbors: Vec<&'a VertexId>) -> VertexIter<'a> {
-        VertexIter {
-            current: 0,
-            iterable: neighbors,
-        }
-    }
-}
+pub struct VertexIter<'a>(pub(crate) Box<dyn 'a + MergedTrait<'a,>>,);
 
 impl<'a> Iterator for VertexIter<'a> {
     type Item = &'a VertexId;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current == self.iterable.len() {
-            return None;
-        }
-
-        let result = self.iterable[self.current];
-        self.current += 1;
-
-        Some(result)
-    }
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> { self.0.next() }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,3 +4,25 @@ macro_rules! min {
     ($x: expr) => ($x);
     ($x: expr, $($z: expr),+) => (::std::cmp::min($x, min!($($z),*)));
 }
+
+/// Returns a HashSet containing the passed values.
+#[macro_export]
+macro_rules! set {
+    ($fst:expr $(, $v:expr)*) => ({
+        let mut set = HashSet::with_capacity(count!($fst $(, $v)*));
+
+        set.insert($fst);
+        $(set.insert($v);)*
+
+        set
+    });
+}
+
+/// Counts the number of values passed to it.
+#[macro_export]
+macro_rules! count {
+    () => (0);
+    ($fst:expr) => (1);
+    ($fst:expr, $snd:expr) => (2);
+    ($fst:expr, $snd:expr $(, $v:expr)*) => (1 + count!($snd $(, $v)*));
+}


### PR DESCRIPTION
The original implementation of `Dfs::is_cyclic` would miss cycles if they had already been iterated over.
I've rewritten `Dfs` to address this edge case since it was ingrained in how `is_cyclic` was using existing computations to check for cycles as it iterates.