### PR TITLE
use of macros in benchmark + rustfmt + no-std fix + travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,19 @@ git:
   depth: 10
 
 before_script:
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then chmod +x benches-compare.sh; fi
+  - chmod +x benches-compare.sh
 
 script:
+  - cargo build --verbose --all
   - cargo build --verbose --all --features "dot"
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     cargo +nightly build --features "no_std dot" --verbose --all;
     fi
+  - cargo test --verbose --all
   - cargo test --verbose --all --features "dot"
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
       cargo +nightly test --features "no_std dot" --verbose --all;
     fi
 
 after_script:
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; ./benches-compare.sh; fi
+  - ./benches-compare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ git:
   depth: 10
 
 before_script:
-  - chmod +x benches-compare.sh
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then chmod +x benches-compare.sh; fi
 
 script:
   - cargo build --verbose --all
@@ -30,4 +30,4 @@ script:
     fi
 
 after_script:
-  - ./benches-compare.sh
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then chmod +x benches-compare.sh; fi

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -12,22 +12,17 @@ use graphlib::*;
 fn bench_create(c: &mut Criterion) {
     c.bench_function("new", |b| b.iter(Graph::<usize>::new));
 
-    c.bench_function("with_capacity_10", |b| {
-        b.iter(|| Graph::<usize>::with_capacity(10))
-    });
-    c.bench_function("with_capacity_100", |b| {
-        b.iter(|| Graph::<usize>::with_capacity(100))
-    });
-    c.bench_function("with_capacity_500", |b| {
-        b.iter(|| Graph::<usize>::with_capacity(500))
-    });
-    c.bench_function("with_capacity_1000", |b| {
-        b.iter(|| Graph::<usize>::with_capacity(1000))
-    });
+    macro_rules! with_capacity {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| b.iter(|| Graph::<usize>::with_capacity($x)));
+        };
+    }
+    with_capacity!("with_capacity_10", 10);
+    with_capacity!("with_capacity_100", 100);
+    with_capacity!("with_capacity_500", 500);
+    with_capacity!("with_capacity_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("with_capacity_m", |b| {
-        b.iter(|| Graph::<usize>::with_capacity(10_000_000))
-    });
+    with_capacity!("with_capacity_m", 10_000_000);
 }
 
 // includes benches for :
@@ -37,458 +32,145 @@ fn bench_create(c: &mut Criterion) {
 // 4. vertices(&self) -> VertexIter
 // 5. roots(&self) -> VertexIter
 fn bench_iterators(c: &mut Criterion) {
-    c.bench_function("dfs_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
+    macro_rules! dfs {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut vertices = vec![];
 
-        let mut v1 = graph.add_vertex(0);
+                let mut v1 = graph.add_vertex(0);
 
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.dfs() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("dfs_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.dfs() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("dfs_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.dfs() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("dfs_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.dfs() {
-                vertices.push(v);
-            }
-        })
-    });
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    for v in graph.dfs() {
+                        vertices.push(v);
+                    }
+                })
+            });
+        };
+    }
+    dfs!("dfs_10", 10);
+    dfs!("dfs_100", 100);
+    dfs!("dfs_500", 500);
+    dfs!("dfs_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("dfs_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
+    dfs!("dfs_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! bfs {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut vertices = vec![];
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
+                let mut v1 = graph.add_vertex(0);
 
-        b.iter(|| {
-            for v in graph.dfs() {
-                vertices.push(v);
-            }
-        })
-    });
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
 
-    c.bench_function("bfs_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.bfs() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("bfs_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.bfs() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("bfs_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.bfs() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("bfs_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.bfs() {
-                vertices.push(v);
-            }
-        })
-    });
+                b.iter(|| {
+                    for v in graph.bfs() {
+                        vertices.push(v);
+                    }
+                })
+            });
+        };
+    }
+    bfs!("bfs_10", 10);
+    bfs!("bfs_100", 100);
+    bfs!("bfs_500", 500);
+    bfs!("bfs_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("bfs_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
+    bfs!("bfs_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! topo {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut vertices = vec![];
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
+                let mut v1 = graph.add_vertex(0);
 
-        b.iter(|| {
-            for v in graph.bfs() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("topo_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.topo() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("topo_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.topo() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("topo_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.topo() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("topo_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.topo() {
-                vertices.push(v);
-            }
-        })
-    });
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    for v in graph.topo() {
+                        vertices.push(v);
+                    }
+                })
+            });
+        };
+    }
+    topo!("topo_10", 10);
+    topo!("topo_100", 100);
+    topo!("topo_500", 500);
+    topo!("topo_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("topo_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
+    topo!("topo_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! vertices {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut vertices = vec![];
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
+                for i in 1..=$x {
+                    graph.add_vertex(i);
+                }
 
-        b.iter(|| {
-            for v in graph.topo() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("vertices_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        for i in 1..=10 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            for v in graph.vertices() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("vertices_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        for i in 1..=100 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            for v in graph.vertices() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("vertices_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        for i in 1..=500 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            for v in graph.vertices() {
-                vertices.push(v);
-            }
-        })
-    });
-
-    c.bench_function("vertices_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
-
-        for i in 1..=1000 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            for v in graph.vertices() {
-                vertices.push(v);
-            }
-        })
-    });
+                b.iter(|| {
+                    for v in graph.vertices() {
+                        vertices.push(v);
+                    }
+                })
+            });
+        };
+    }
+    vertices!("vertices_10", 10);
+    vertices!("vertices_100", 100);
+    vertices!("vertices_500", 500);
+    vertices!("vertices_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("vertices_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut vertices = vec![];
+    vertices!("vertices_m", 10_000_000);
 
-        for i in 1..=10_000_000 {
-            graph.add_vertex(i);
-        }
+    macro_rules! roots {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut roots = vec![];
 
-        b.iter(|| {
-            for v in graph.vertices() {
-                vertices.push(v);
-            }
-        })
-    });
+                let mut v1 = graph.add_vertex(0);
 
-    c.bench_function("roots_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut roots = vec![];
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
 
-        let mut v1 = graph.add_vertex(0);
+                b.iter(|| {
+                    for v in graph.roots() {
+                        roots.push(v);
+                    }
+                })
+            });
+        };
+    }
 
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.roots() {
-                roots.push(v);
-            }
-        })
-    });
-
-    c.bench_function("roots_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut roots = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.roots() {
-                roots.push(v);
-            }
-        })
-    });
-
-    c.bench_function("roots_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut roots = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.roots() {
-                roots.push(v);
-            }
-        })
-    });
-
-    c.bench_function("roots_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut roots = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.roots() {
-                roots.push(v);
-            }
-        })
-    });
+    roots!("roots_10", 10);
+    roots!("roots_100", 100);
+    roots!("roots_500", 500);
+    roots!("roots_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("roots_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut roots = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.roots() {
-                roots.push(v);
-            }
-        })
-    });
+    roots!("roots_m", 10_000_000);
 }
 
 // includes benches for :
@@ -499,498 +181,168 @@ fn bench_iterators(c: &mut Criterion) {
 // 5. out_neighbors(&self, id: &VertexId) -> VertexIter
 // 6. out_neighbors_count(&self, id: &VertexId) -> usize
 fn bench_neighbor_functions(c: &mut Criterion) {
-    c.bench_function("neighbors_count_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    macro_rules! neighbors_count {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
 
-        let mut v1 = graph.add_vertex(0);
+                let mut v1 = graph.add_vertex(0);
 
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
 
-        b.iter(|| {
-            let _k = graph.neighbors_count(&v1);
-        })
-    });
-
-    c.bench_function("neighbors_count_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            let _k = graph.neighbors_count(&v1);
-        })
-    });
-
-    c.bench_function("neighbors_count_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            let _k = graph.neighbors_count(&v1);
-        })
-    });
-
-    c.bench_function("neighbors_count_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            let _k = graph.neighbors_count(&v1);
-        })
-    });
-
+                b.iter(|| {
+                    let _k = graph.neighbors_count(&v1);
+                })
+            });
+        };
+    }
+    neighbors_count!("neighbors_count_10", 10);
+    neighbors_count!("neighbors_count_100", 100);
+    neighbors_count!("neighbors_count_500", 500);
+    neighbors_count!("neighbors_count_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("neighbors_count_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    neighbors_count!("neighbors_count_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! in_neighbors_count {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
+                let mut v1 = graph.add_vertex(0);
 
-        b.iter(|| {
-            let _k = graph.neighbors_count(&v1);
-        })
-    });
-
-    c.bench_function("in_neighbors_count_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.in_neighbors_count(&v1);
-        })
-    });
-
-    c.bench_function("in_neighbors_count_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.in_neighbors_count(&v1);
-        })
-    });
-
-    c.bench_function("in_neighbors_count_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.in_neighbors_count(&v1);
-        })
-    });
-
-    c.bench_function("in_neighbors_count_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.in_neighbors_count(&v1);
-        })
-    });
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    let _k = graph.in_neighbors_count(&v1);
+                })
+            });
+        };
+    }
+    in_neighbors_count!("in_neighbors_count_10", 10);
+    in_neighbors_count!("in_neighbors_count_100", 100);
+    in_neighbors_count!("in_neighbors_count_500", 500);
+    in_neighbors_count!("in_neighbors_count_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("in_neighbors_count_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    in_neighbors_count!("in_neighbors_count_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! out_neighbors_count {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.in_neighbors_count(&v1);
-        })
-    });
+                let mut v1 = graph.add_vertex(0);
 
-    c.bench_function("out_neighbors_count_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    let _k = graph.out_neighbors_count(&v1);
+                })
+            });
+        };
+    }
 
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.out_neighbors_count(&v1);
-        })
-    });
-    c.bench_function("out_neighbors_count_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.out_neighbors_count(&v1);
-        })
-    });
-    c.bench_function("out_neighbors_count_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.out_neighbors_count(&v1);
-        })
-    });
-    c.bench_function("out_neighbors_count_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.out_neighbors_count(&v1);
-        })
-    });
+    out_neighbors_count!("out_neighbors_count_10", 10);
+    out_neighbors_count!("out_neighbors_count_100", 100);
+    out_neighbors_count!("out_neighbors_count_500", 500);
+    out_neighbors_count!("out_neighbors_count_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("out_neighbors_count_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    out_neighbors_count!("out_neighbors_count_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! in_neighbors {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut neighbors = vec![];
+                let mut graph: Graph<usize> = Graph::new();
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.out_neighbors_count(&v1);
-        })
-    });
-    c.bench_function("in_neighbors_10", |b| {
-        let mut neighbors = vec![];
-        let mut graph: Graph<usize> = Graph::new();
+                let mut v1 = graph.add_vertex(0);
 
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.in_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("in_neighbors_100", |b| {
-        let mut neighbors = vec![];
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.in_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("in_neighbors_500", |b| {
-        let mut neighbors = vec![];
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.in_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("in_neighbors_1000", |b| {
-        let mut neighbors = vec![];
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.in_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    for v in graph.in_neighbors(&v1) {
+                        neighbors.push(v);
+                    }
+                })
+            });
+        };
+    }
+    in_neighbors!("in_neighbors_10", 10);
+    in_neighbors!("in_neighbors_100", 100);
+    in_neighbors!("in_neighbors_500", 500);
+    in_neighbors!("in_neighbors_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("in_neighbors_m", |b| {
-        let mut neighbors = vec![];
-        let mut graph: Graph<usize> = Graph::new();
+    in_neighbors!("in_neighbors_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! out_neighbors {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut neighbors = vec![];
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.in_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("out_neighbors_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
+                let mut v1 = graph.add_vertex(0);
 
-        let mut v1 = graph.add_vertex(0);
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    for v in graph.out_neighbors(&v1) {
+                        neighbors.push(v);
+                    }
+                })
+            });
+        };
+    }
 
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.out_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-
-    c.bench_function("out_neighbors_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.out_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("out_neighbors_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.out_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("out_neighbors_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.out_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
+    out_neighbors!("out_neighbors_10", 10);
+    out_neighbors!("out_neighbors_100", 100);
+    out_neighbors!("out_neighbors_500", 500);
+    out_neighbors!("out_neighbors_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("out_neighbors_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
+    out_neighbors!("out_neighbors_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! neighbors {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut neighbors = vec![];
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            for v in graph.out_neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("neighbors_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
+                let mut v1 = graph.add_vertex(0);
 
-        let mut v1 = graph.add_vertex(0);
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
 
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("neighbors_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-
-    c.bench_function("neighbors_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
-    c.bench_function("neighbors_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
+                b.iter(|| {
+                    for v in graph.neighbors(&v1) {
+                        neighbors.push(v);
+                    }
+                })
+            });
+        };
+    }
+    neighbors!("neighbors_10", 10);
+    neighbors!("neighbors_100", 100);
+    neighbors!("neighbors_500", 500);
+    neighbors!("neighbors_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("neighbors_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut neighbors = vec![];
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-
-        b.iter(|| {
-            for v in graph.neighbors(&v1) {
-                neighbors.push(v);
-            }
-        })
-    });
+    neighbors!("neighbors_m", 10_000_000);
 }
 
 // includes benches for :
@@ -1011,975 +363,388 @@ fn bench_neighbor_functions(c: &mut Criterion) {
 // 15.shrink_to_fit(&mut self)
 // 16.vertex_count(&self) -> usize
 fn bench_others(c: &mut Criterion) {
-    c.bench_function("add_edge_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
+    macro_rules! add_edge {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                b.iter(|| {
+                    let mut v1 = graph.add_vertex(0);
 
-            for i in 1..=10 {
-                let v2 = graph.add_vertex(i);
+                    for i in 1..=$x {
+                        let v2 = graph.add_vertex(i);
+                        graph.add_edge(&v1, &v2);
+                        v1 = v2.clone();
+                    }
+                })
+            });
+        };
+    }
+    add_edge!("add_edge_10", 10);
+    add_edge!("add_edge_100", 100);
+    add_edge!("add_edge_500", 500);
+    add_edge!("add_edge_1000", 1000);
+    #[cfg(feature = "sbench")]
+    add_edge!("add_edge_m", 10_000_000);
+
+    macro_rules! add_edge_cycle_check {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                b.iter(|| {
+                    let mut v1 = graph.add_vertex(0);
+
+                    for i in 1..=$x {
+                        let v2 = graph.add_vertex(i);
+                        graph.add_edge_check_cycle(&v1, &v2);
+                        v1 = v2.clone();
+                    }
+                })
+            });
+        };
+    }
+    add_edge_cycle_check!("add_edge_cycle_check_10", 10);
+    add_edge_cycle_check!("add_edge_cycle_check_100", 100);
+    add_edge_cycle_check!("add_edge_cycle_check_500", 500);
+    add_edge_cycle_check!("add_edge_cycle_check_1000", 1000);
+    #[cfg(feature = "sbench")]
+    add_edge_cycle_check!("add_edge_cycle_check_m", 10_000_000);
+
+    macro_rules! add_vertex {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                b.iter(|| {
+                    for i in 1..=$x {
+                        graph.add_vertex(i);
+                    }
+                })
+            });
+        };
+    }
+    add_vertex!("add_vertex_10", 10);
+    add_vertex!("add_vertex_100", 100);
+    add_vertex!("add_vertex_500", 500);
+    add_vertex!("add_vertex_1000", 1000);
+    #[cfg(feature = "sbench")]
+    add_vertex!("add_vertex_m", 10_000_000);
+
+    macro_rules! capacity {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let graph: Graph<usize> = Graph::with_capacity($x);
+                b.iter(|| {
+                    let _k = graph.capacity();
+                })
+            });
+        };
+    }
+
+    capacity!("capacity_10", 10);
+    capacity!("capacity_100", 100);
+    capacity!("capacity_500", 500);
+    capacity!("capacity_1000", 1000);
+    #[cfg(feature = "sbench")]
+    capacity!("capacity_m", 10_000_000);
+
+    macro_rules! edge_count {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+
+                let mut v1 = graph.add_vertex(0);
+
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    let _k = graph.edge_count();
+                })
+            });
+        };
+    }
+    edge_count!("edge_count_10", 10);
+    edge_count!("edge_count_100", 100);
+    edge_count!("edge_count_500", 500);
+    edge_count!("edge_count_1000", 1000);
+    #[cfg(feature = "sbench")]
+    edge_count!("edge_count_m", 10_000_000);
+
+    macro_rules! fetch {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+
+                for i in 1..$x {
+                    graph.add_vertex(i);
+                }
+                let id = graph.add_vertex($x);
+                b.iter(|| {
+                    let _k = *graph.fetch(&id).unwrap();
+                })
+            });
+        };
+    }
+    fetch!("fetch_10", 10);
+    fetch!("fetch_100", 100);
+    fetch!("fetch_500", 500);
+    fetch!("fetch_1000", 1000);
+    #[cfg(feature = "sbench")]
+    fetch!("fetch_m", 10_000_000);
+
+    macro_rules! fetch_mut {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                for i in 1..$x {
+                    graph.add_vertex(i);
+                }
+                let id = graph.add_vertex($x);
+                b.iter(|| {
+                    let _v = graph.fetch_mut(&id).unwrap();
+                })
+            });
+        };
+    }
+    fetch_mut!("fetch_mut_10", 10);
+    fetch_mut!("fetch_mut_100", 100);
+    fetch_mut!("fetch_mut_500", 500);
+    fetch_mut!("fetch_mut_1000", 1000);
+    #[cfg(feature = "sbench")]
+    fetch_mut!("fetch_mut_m", 10_000_000);
+
+    macro_rules! fold {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+
+                for i in 1..=$x {
+                    graph.add_vertex(i);
+                }
+
+                b.iter(|| {
+                    let _result = graph.fold(0, |v, acc| v + acc);
+                })
+            });
+        };
+    }
+    fold!("fold_10", 10);
+    fold!("fold_100", 100);
+    fold!("fold_500", 500);
+    fold!("fold_1000", 1000);
+    #[cfg(feature = "sbench")]
+    fold!("fold_m", 10_000_000);
+
+    macro_rules! has_edge {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+
+                let v1 = graph.add_vertex(1);
+                let v2 = graph.add_vertex(2);
+
+                for i in 3..=$x {
+                    graph.add_vertex(i);
+                }
+                let v3 = graph.add_vertex(3);
+
+                graph.add_edge(&v1, &v2).unwrap();
+                b.iter(|| {
+                    let _k = graph.has_edge(&v1, &v2);
+                    let _l = graph.has_edge(&v2, &v3);
+                })
+            });
+        };
+    }
+    has_edge!("has_edge_10", 10);
+    has_edge!("has_edge_100", 100);
+    has_edge!("has_edge_500", 500);
+    has_edge!("has_edge_1000", 1000);
+    #[cfg(feature = "sbench")]
+    has_edge!("has_edge_m", 10_000_000);
+
+    macro_rules! is_cyclic {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+
+                let v0 = graph.add_vertex(0);
+                let mut v1 = graph.add_vertex(1);
+                let mut v2 = graph.add_vertex(2);
+                graph.add_edge(&v0, &v1);
                 graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
-
-    c.bench_function("add_edge_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=100 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
-    c.bench_function("add_edge_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=500 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
-    c.bench_function("add_edge_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=1000 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
+                for i in 4..=$x {
+                    v1 = v2.clone();
+                    v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                }
+                graph.add_edge(&v2, &v0);
+                b.iter(|| {
+                    let _k = graph.is_cyclic();
+                })
+            });
+        };
+    }
+    is_cyclic!("is_cyclic_10", 10);
+    is_cyclic!("is_cyclic_100", 100);
+    is_cyclic!("is_cyclic_500", 500);
+    is_cyclic!("is_cyclic_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("add_edge_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
+    is_cyclic!("is_cyclic_m", 10_000_000);
 
-            for i in 1..=10_000_000 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
-    c.bench_function("add_edge_cycle_check_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=10 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge_check_cycle(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
-
-    c.bench_function("add_edge_cycle_check_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=100 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge_check_cycle(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
+    macro_rules! remove {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                b.iter(|| {
+                    for i in 1..=$x {
+                        let v1 = graph.add_vertex(i);
+                        graph.remove(&v1);
+                    }
+                })
+            });
+        };
+    }
+    remove!("remove_10", 10);
+    remove!("remove_100", 100);
+    remove!("remove_500", 500);
+    remove!("remove_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("add_edge_cycle_check_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
+    remove!("remove_m", 10_000_000);
 
-            for i in 1..=10_000_000 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge_check_cycle(&v1, &v2);
-                v1 = v2.clone();
-            }
-        })
-    });
-    c.bench_function("add_vertex_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=10 {
-                graph.add_vertex(i);
-            }
-        })
-    });
+    macro_rules! remove_edge {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                b.iter(|| {
+                    let mut v1 = graph.add_vertex(0);
 
-    c.bench_function("add_vertex_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=100 {
-                graph.add_vertex(i);
-            }
-        })
-    });
+                    for i in 1..=$x {
+                        let v2 = graph.add_vertex(i);
+                        graph.add_edge(&v1, &v2);
+                        v1 = v2.clone();
+                        graph.remove_edge(&v1, &v2);
+                    }
+                })
+            });
+        };
+    }
 
-    c.bench_function("add_vertex_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=500 {
-                graph.add_vertex(i);
-            }
-        })
-    });
-    c.bench_function("add_vertex_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=1000 {
-                graph.add_vertex(i);
-            }
-        })
-    });
+    remove_edge!("remove_edge_10", 10);
+    remove_edge!("remove_edge_100", 100);
+    remove_edge!("remove_edge_500", 500);
+    remove_edge!("remove_edge_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("add_vertex_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=10_000_000 {
-                graph.add_vertex(i);
-            }
-        })
-    });
+    remove_edge!("remove_edge_m", 10_000_000);
 
-    c.bench_function("capacity_10", |b| {
-        let graph: Graph<usize> = Graph::with_capacity(10);
-        b.iter(|| {
-            let _k = graph.capacity();
-        })
-    });
-    c.bench_function("capacity_100", |b| {
-        let graph: Graph<usize> = Graph::with_capacity(100);
-        b.iter(|| {
-            let _k = graph.capacity();
-        })
-    });
-    c.bench_function("capacity_500", |b| {
-        let graph: Graph<usize> = Graph::with_capacity(500);
-        b.iter(|| {
-            let _k = graph.capacity();
-        })
-    });
+    macro_rules! reserve {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::with_capacity($x);
 
-    c.bench_function("capacity_1000", |b| {
-        let graph: Graph<usize> = Graph::with_capacity(1000);
-        b.iter(|| {
-            let _k = graph.capacity();
-        })
-    });
+                for i in 1..=$x {
+                    graph.add_vertex(i);
+                }
+
+                b.iter(|| {
+                    graph.reserve($x);
+                })
+            });
+        };
+    }
+
+    reserve!("reserve_10", 10);
+    reserve!("reserve_100", 100);
+    reserve!("reserve_500", 500);
+    reserve!("reserve_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("capacity_m", |b| {
-        let graph: Graph<usize> = Graph::with_capacity(10_000_000);
-        b.iter(|| {
-            let _k = graph.capacity();
-        })
-    });
+    reserve!("reserve_m", 10_000_000);
 
-    c.bench_function("edge_count_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    macro_rules! retain {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
 
-        let mut v1 = graph.add_vertex(0);
+                for i in 1..=$x {
+                    graph.add_vertex(i);
+                }
+                b.iter(|| {
+                    graph.retain(|v| *v != 2);
+                })
+            });
+        };
+    }
 
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.edge_count();
-        })
-    });
-    c.bench_function("edge_count_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.edge_count();
-        })
-    });
-
-    c.bench_function("edge_count_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.edge_count();
-        })
-    });
-    c.bench_function("edge_count_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.edge_count();
-        })
-    });
+    retain!("retain_10", 10);
+    retain!("retain_100", 100);
+    retain!("retain_500", 500);
+    retain!("retain_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("edge_count_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    retain!("retain_m", 10_000_000);
 
-        let mut v1 = graph.add_vertex(0);
+    macro_rules! roots_count {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
+                let mut v1 = graph.add_vertex(0);
 
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.edge_count();
-        })
-    });
-    c.bench_function("fetch_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..10 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(10);
-        b.iter(|| {
-            let _k = *graph.fetch(&id).unwrap();
-        })
-    });
-    c.bench_function("fetch_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..100 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(100);
-        b.iter(|| {
-            let _k = *graph.fetch(&id).unwrap();
-        })
-    });
-    c.bench_function("fetch_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..500 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(500);
-        b.iter(|| {
-            let _k = *graph.fetch(&id).unwrap();
-        })
-    });
-    c.bench_function("fetch_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..1000 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(1000);
-        b.iter(|| {
-            let _k = *graph.fetch(&id).unwrap();
-        })
-    });
+                for i in 1..=$x {
+                    let v2 = graph.add_vertex(i);
+                    graph.add_edge(&v1, &v2);
+                    v1 = v2.clone();
+                }
+                b.iter(|| {
+                    let _k = graph.roots_count();
+                })
+            });
+        };
+    }
+    roots_count!("roots_count_10", 10);
+    roots_count!("roots_count_100", 100);
+    roots_count!("roots_count_500", 500);
+    roots_count!("roots_count_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("fetch_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    roots_count!("roots_count_m", 10_000_000);
 
-        for i in 1..10_000_000 {
-            graph.add_vertex(i);
-        }
-        let mut id = graph.add_vertex(10_000_000);
-        b.iter(|| {
-            let _k = *graph.fetch(&id).unwrap();
-        })
-    });
+    macro_rules! shrink_to_fit {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::with_capacity($x);
 
-    c.bench_function("fetch_mut_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        for i in 1..10 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(10);
-        b.iter(|| {
-            let _v = graph.fetch_mut(&id).unwrap();
-        })
-    });
-    c.bench_function("fetch_mut_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        for i in 1..100 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(100);
-        b.iter(|| {
-            let _v = graph.fetch_mut(&id).unwrap();
-        })
-    });
-    c.bench_function("fetch_mut_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        for i in 1..500 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(500);
-        b.iter(|| {
-            let _v = graph.fetch_mut(&id).unwrap();
-        })
-    });
-    c.bench_function("fetch_mut_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        for i in 1..1000 {
-            graph.add_vertex(i);
-        }
-        let id = graph.add_vertex(1000);
-        b.iter(|| {
-            let _v = graph.fetch_mut(&id).unwrap();
-        })
-    });
-
+                b.iter(|| {
+                    graph.shrink_to_fit();
+                })
+            });
+        };
+    }
+    shrink_to_fit!("shrink_to_fit_10", 10);
+    shrink_to_fit!("shrink_to_fit_100", 100);
+    shrink_to_fit!("shrink_to_fit_500", 500);
+    shrink_to_fit!("shrink_to_fit_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("fetch_mut_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        for i in 1..10_000_000 {
-            graph.add_vertex(i);
-        }
-        let mut id = graph.add_vertex(10_000_000);
-        b.iter(|| {
-            let _v = graph.fetch_mut(&id).unwrap();
-        })
-    });
-    c.bench_function("fold_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
+    shrink_to_fit!("shrink_to_fit_m", 10_000_000);
 
-        for i in 1..=10 {
-            graph.add_vertex(i);
-        }
+    macro_rules! vertex_count {
+        ($str: tt ,$x: expr) => {
+            c.bench_function($str, |b| {
+                let mut graph: Graph<usize> = Graph::new();
 
-        b.iter(|| {
-            let _result = graph.fold(0, |v, acc| v + acc);
-        })
-    });
-    c.bench_function("fold_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=100 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            let _result = graph.fold(0, |v, acc| v + acc);
-        })
-    });
-    c.bench_function("fold_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=500 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            let _result = graph.fold(0, |v, acc| v + acc);
-        })
-    });
-    c.bench_function("fold_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=1000 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            let _result = graph.fold(0, |v, acc| v + acc);
-        })
-    });
+                for i in 1..=$x {
+                    graph.add_vertex(i);
+                }
+                b.iter(|| {
+                    let _k = graph.vertex_count();
+                })
+            });
+        };
+    }
+    vertex_count!("vertex_count_10", 10);
+    vertex_count!("vertex_count_100", 100);
+    vertex_count!("vertex_count_500", 500);
+    vertex_count!("vertex_count_1000", 1000);
     #[cfg(feature = "sbench")]
-    c.bench_function("fold_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=10_000_000 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            let _result = graph.fold(0, |v, acc| v + acc);
-        })
-    });
-    c.bench_function("has_edge_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v1 = graph.add_vertex(1);
-        let v2 = graph.add_vertex(2);
-
-        for i in 3..=10 {
-            graph.add_vertex(i);
-        }
-        let v3 = graph.add_vertex(3);
-
-        graph.add_edge(&v1, &v2).unwrap();
-        b.iter(|| {
-            let _k = graph.has_edge(&v1, &v2);
-            let _l = graph.has_edge(&v2, &v3);
-        })
-    });
-    c.bench_function("has_edge_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v1 = graph.add_vertex(1);
-        let v2 = graph.add_vertex(2);
-
-        for i in 3..=100 {
-            graph.add_vertex(i);
-        }
-        let v3 = graph.add_vertex(3);
-
-        graph.add_edge(&v1, &v2).unwrap();
-        b.iter(|| {
-            let _k = graph.has_edge(&v1, &v2);
-            let _l = graph.has_edge(&v2, &v3);
-        })
-    });
-
-    c.bench_function("has_edge_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v1 = graph.add_vertex(1);
-        let v2 = graph.add_vertex(2);
-
-        for i in 3..=500 {
-            graph.add_vertex(i);
-        }
-        let v3 = graph.add_vertex(3);
-
-        graph.add_edge(&v1, &v2).unwrap();
-        b.iter(|| {
-            let _k = graph.has_edge(&v1, &v2);
-            let _l = graph.has_edge(&v2, &v3);
-        })
-    });
-
-    c.bench_function("has_edge_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v1 = graph.add_vertex(1);
-        let v2 = graph.add_vertex(2);
-
-        for i in 3..=1000 {
-            graph.add_vertex(i);
-        }
-        let v3 = graph.add_vertex(3);
-
-        graph.add_edge(&v1, &v2).unwrap();
-        b.iter(|| {
-            let _k = graph.has_edge(&v1, &v2);
-            let _l = graph.has_edge(&v2, &v3);
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("has_edge_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v1 = graph.add_vertex(1);
-        let v2 = graph.add_vertex(2);
-
-        for i in 3..=10_000_000 {
-            graph.add_vertex(i);
-        }
-        let v3 = graph.add_vertex(3);
-
-        graph.add_edge(&v1, &v2).unwrap();
-        b.iter(|| {
-            let _k = graph.has_edge(&v1, &v2);
-            let _l = graph.has_edge(&v2, &v3);
-        })
-    });
-    c.bench_function("is_cyclic_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v0 = graph.add_vertex(0);
-        let mut v1 = graph.add_vertex(1);
-        let mut v2 = graph.add_vertex(2);
-        graph.add_edge(&v0, &v1);
-        graph.add_edge(&v1, &v2);
-        for i in 4..=10 {
-            v1 = v2.clone();
-            v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-        }
-        graph.add_edge(&v2, &v0);
-        b.iter(|| {
-            let _k = graph.is_cyclic();
-        })
-    });
-    c.bench_function("is_cyclic_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v0 = graph.add_vertex(0);
-        let mut v1 = graph.add_vertex(1);
-        let mut v2 = graph.add_vertex(2);
-        graph.add_edge(&v0, &v1);
-        graph.add_edge(&v1, &v2);
-        for i in 4..=100 {
-            v1 = v2.clone();
-            v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-        }
-        graph.add_edge(&v2, &v0);
-        b.iter(|| {
-            let _k = graph.is_cyclic();
-        })
-    });
-    c.bench_function("is_cyclic_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v0 = graph.add_vertex(0);
-        let mut v1 = graph.add_vertex(1);
-        let mut v2 = graph.add_vertex(2);
-        graph.add_edge(&v0, &v1);
-        graph.add_edge(&v1, &v2);
-        for i in 4..=500 {
-            v1 = v2.clone();
-            v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-        }
-        graph.add_edge(&v2, &v0);
-        b.iter(|| {
-            let _k = graph.is_cyclic();
-        })
-    });
-    c.bench_function("is_cyclic_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v0 = graph.add_vertex(0);
-        let mut v1 = graph.add_vertex(1);
-        let mut v2 = graph.add_vertex(2);
-        graph.add_edge(&v0, &v1);
-        graph.add_edge(&v1, &v2);
-        for i in 4..=1000 {
-            v1 = v2.clone();
-            v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-        }
-        graph.add_edge(&v2, &v0);
-        b.iter(|| {
-            let _k = graph.is_cyclic();
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("is_cyclic_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        let v0 = graph.add_vertex(0);
-        let mut v1 = graph.add_vertex(1);
-        let mut v2 = graph.add_vertex(2);
-        graph.add_edge(&v0, &v1);
-        graph.add_edge(&v1, &v2);
-        for i in 4..=10_000_000 {
-            v1 = v2.clone();
-            v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-        }
-        graph.add_edge(&v2, &v0);
-        b.iter(|| {
-            let _k = graph.is_cyclic();
-        })
-    });
-    c.bench_function("remove_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=10 {
-                let v1 = graph.add_vertex(i);
-                graph.remove(&v1);
-            }
-        })
-    });
-    c.bench_function("remove_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=100 {
-                let v1 = graph.add_vertex(i);
-                graph.remove(&v1);
-            }
-        })
-    });
-    c.bench_function("remove_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=500 {
-                let v1 = graph.add_vertex(i);
-                graph.remove(&v1);
-            }
-        })
-    });
-    c.bench_function("remove_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=1000 {
-                let v1 = graph.add_vertex(i);
-                graph.remove(&v1);
-            }
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("remove_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            for i in 1..=10_000_000 {
-                let v1 = graph.add_vertex(i);
-                graph.remove(&v1);
-            }
-        })
-    });
-    c.bench_function("remove_edge_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=10 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-                graph.remove_edge(&v1, &v2);
-            }
-        })
-    });
-    c.bench_function("remove_edge_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=100 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-                graph.remove_edge(&v1, &v2);
-            }
-        })
-    });
-
-    c.bench_function("remove_edge_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=500 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-                graph.remove_edge(&v1, &v2);
-            }
-        })
-    });
-
-    c.bench_function("remove_edge_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=1000 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-                graph.remove_edge(&v1, &v2);
-            }
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("remove_edge_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        b.iter(|| {
-            let mut v1 = graph.add_vertex(0);
-
-            for i in 1..=10_000_000 {
-                let v2 = graph.add_vertex(i);
-                graph.add_edge(&v1, &v2);
-                v1 = v2.clone();
-                graph.remove_edge(&v1, &v2);
-            }
-        })
-    });
-
-    c.bench_function("reserve_10", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(10);
-
-        for i in 1..=10 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            graph.reserve(10);
-        })
-    });
-    c.bench_function("reserve_100", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(100);
-
-        for i in 1..=100 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            graph.reserve(100);
-        })
-    });
-    c.bench_function("reserve_500", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(500);
-
-        for i in 1..=500 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            graph.reserve(500);
-        })
-    });
-    c.bench_function("reserve_1000", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(1000);
-
-        for i in 1..=1000 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            graph.reserve(1000);
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("reserve_m", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(10_000_000);
-
-        for i in 1..=10_000_000 {
-            graph.add_vertex(i);
-        }
-
-        b.iter(|| {
-            graph.reserve(10_000_000);
-        })
-    });
-    c.bench_function("retain_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=10 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            graph.retain(|v| *v != 2);
-        })
-    });
-    c.bench_function("retain_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=100 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            graph.retain(|v| *v != 2);
-        })
-    });
-    c.bench_function("retain_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=500 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            graph.retain(|v| *v != 2);
-        })
-    });
-    c.bench_function("retain_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=1000 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            graph.retain(|v| *v != 2);
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("retain_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=10_000_000 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            graph.retain(|v| *v != 2);
-        })
-    });
-    c.bench_function("roots_count_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.roots_count();
-        })
-    });
-    c.bench_function("roots_count_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=100 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.roots_count();
-        })
-    });
-    c.bench_function("roots_count_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=500 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.roots_count();
-        })
-    });
-    c.bench_function("roots_count_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=1000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.roots_count();
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("roots_count_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-        let mut v1 = graph.add_vertex(0);
-
-        for i in 1..=10_000_000 {
-            let v2 = graph.add_vertex(i);
-            graph.add_edge(&v1, &v2);
-            v1 = v2.clone();
-        }
-        b.iter(|| {
-            let _k = graph.roots_count();
-        })
-    });
-
-    c.bench_function("shrink_to_fit_10", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(10);
-
-        b.iter(|| {
-            graph.shrink_to_fit();
-        })
-    });
-    c.bench_function("shrink_to_fit_100", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(100);
-
-        b.iter(|| {
-            graph.shrink_to_fit();
-        })
-    });
-    c.bench_function("shrink_to_fit_500", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(500);
-
-        b.iter(|| {
-            graph.shrink_to_fit();
-        })
-    });
-    c.bench_function("shrink_to_fit_1000", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(1000);
-
-        b.iter(|| {
-            graph.shrink_to_fit();
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("shrink_to_fit_m", |b| {
-        let mut graph: Graph<usize> = Graph::with_capacity(10_000_000);
-
-        b.iter(|| {
-            graph.shrink_to_fit();
-        })
-    });
-    c.bench_function("vertex_count_10", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=10 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            let _k = graph.vertex_count();
-        })
-    });
-    c.bench_function("vertex_count_100", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=100 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            let _k = graph.vertex_count();
-        })
-    });
-    c.bench_function("vertex_count_500", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=500 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            let _k = graph.vertex_count();
-        })
-    });
-    c.bench_function("vertex_count_1000", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=1000 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            let _k = graph.vertex_count();
-        })
-    });
-    #[cfg(feature = "sbench")]
-    c.bench_function("vertex_count_m", |b| {
-        let mut graph: Graph<usize> = Graph::new();
-
-        for i in 1..=10_000_000 {
-            graph.add_vertex(i);
-        }
-        b.iter(|| {
-            let _k = graph.vertex_count();
-        })
-    });
+    vertex_count!("vertex_count_m", 10_000_000);
 }
 
 criterion_group!(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -301,9 +301,9 @@ impl<T> Graph<T> {
 
     /// Attempts to place a new edge in the graph, checking if the specified
     /// edge will create a cycle in the graph. If it does, this operation will fail.
-    /// 
+    ///
     /// Note that this operation has a bigger performance hit than `Graph::add_edge()`.
-    /// 
+    ///
     /// /// ## Example
     /// ```rust
     /// use graphlib::{Graph, GraphErr, VertexId};
@@ -1293,9 +1293,9 @@ impl<T> Graph<T> {
         }
     }
 
-    /// Returns an iterator over the values of the vertices 
+    /// Returns an iterator over the values of the vertices
     /// placed in the graph.
-    /// 
+    ///
     /// ## Example
     /// ```rust
     /// #[macro_use] extern crate graphlib;
@@ -1313,9 +1313,7 @@ impl<T> Graph<T> {
     /// assert!(set![&1, &2, &3] == values.collect());
     /// ```
     pub fn values(&self) -> ValuesIter<'_, T> {
-        let iter = self.vertices
-            .values()
-            .map(|(v, _)| v);
+        let iter = self.vertices.values().map(|(v, _)| v);
 
         ValuesIter(Box::new(iter))
     }
@@ -1370,7 +1368,7 @@ impl<T> Graph<T> {
 
     #[cfg(feature = "dot")]
     /// Labels the vertex with the given id. Returns the old label if successful.
-    /// 
+    ///
     /// This method requires the `dot` crate feature.
     ///
     /// ## Example
@@ -1405,7 +1403,7 @@ impl<T> Graph<T> {
 
     #[cfg(feature = "dot")]
     /// Retrieves the label of the vertex with the given id.
-    /// 
+    ///
     /// This method requires the `dot` crate feature.
     ///
     /// This function will return a default label if no label is set. Returns
@@ -1441,7 +1439,7 @@ impl<T> Graph<T> {
 
     #[cfg(feature = "dot")]
     /// Maps each label that is placed on a vertex to a new label.
-    /// 
+    ///
     /// This method requires the `dot` crate feature.
     ///
     /// ```rust
@@ -1498,7 +1496,13 @@ impl<T> Graph<T> {
         }
     }
 
-    fn do_add_edge(&mut self, a: &VertexId, b: &VertexId, weight: f32, check_cycle: bool) -> Result<(), GraphErr> {
+    fn do_add_edge(
+        &mut self,
+        a: &VertexId,
+        b: &VertexId,
+        weight: f32,
+        check_cycle: bool,
+    ) -> Result<(), GraphErr> {
         let id_ptr1 = if self.vertices.get(a).is_some() {
             *a
         } else {
@@ -1769,23 +1773,26 @@ mod tests {
     #[test]
     fn test_add_edge_cycle_check() {
         let mut graph: Graph<usize> = Graph::new();
-    
+
         // Id of vertex that is not place in the graph
         let id = VertexId::random();
-    
+
         let v1 = graph.add_vertex(1);
         let v2 = graph.add_vertex(2);
-    
+
         // Adding an edge is idempotent
         graph.add_edge_check_cycle(&v1, &v2).unwrap();
         graph.add_edge_check_cycle(&v1, &v2).unwrap();
         graph.add_edge_check_cycle(&v1, &v2).unwrap();
 
         let mut graph2 = graph.clone();
-    
+
         // Fails on adding an edge which creates
         // a cycle in the graph.
-        assert_eq!(graph2.add_edge_check_cycle(&v2, &v1), Err(GraphErr::CycleError));
+        assert_eq!(
+            graph2.add_edge_check_cycle(&v2, &v1),
+            Err(GraphErr::CycleError)
+        );
 
         // Check that the graph state has rolled back
         assert_eq!(graph.edges, graph2.edges);

--- a/src/iterators/dijkstra.rs
+++ b/src/iterators/dijkstra.rs
@@ -1,15 +1,21 @@
 // Copyright 2019 Chakrapani Gautam
 
 use crate::graph::{Graph, GraphErr};
-use crate::iterators::vertices::VertexIter;
 use crate::iterators::owning_iterator::OwningIterator;
+use crate::iterators::vertices::VertexIter;
 use crate::vertex_id::VertexId;
 
 use hashbrown::HashMap;
 use hashbrown::HashSet;
 
 #[cfg(not(feature = "no_std"))]
-use std::{cmp::Ordering, collections::{BinaryHeap, VecDeque}, f32, fmt::Debug, iter};
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, VecDeque},
+    f32,
+    fmt::Debug,
+    iter,
+};
 
 #[cfg(feature = "no_std")]
 extern crate alloc;

--- a/src/iterators/dijkstra.rs
+++ b/src/iterators/dijkstra.rs
@@ -20,7 +20,9 @@ use std::{
 #[cfg(feature = "no_std")]
 extern crate alloc;
 #[cfg(feature = "no_std")]
-use alloc::collections::binary_heap::{BinaryHeap, VecDeque};
+use alloc::boxed::Box;
+#[cfg(feature = "no_std")]
+use alloc::collections::{binary_heap::BinaryHeap, vec_deque::VecDeque};
 
 #[cfg(feature = "no_std")]
 use core::{cmp::Ordering, f32, fmt::Debug, iter};

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -3,14 +3,14 @@
 mod bfs;
 mod dfs;
 mod dijkstra;
-mod topo;
-mod vertices;
 mod owning_iterator;
+mod topo;
 mod values;
+mod vertices;
 
 pub use bfs::*;
 pub use dfs::*;
 pub use dijkstra::*;
 pub use topo::*;
-pub use vertices::*;
 pub use values::*;
+pub use vertices::*;

--- a/src/iterators/owning_iterator.rs
+++ b/src/iterators/owning_iterator.rs
@@ -15,10 +15,10 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 #[cfg(feature = "no_std")]
-use alloc::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[cfg(feature = "no_std")]
-use alloc::mem;
+use core::mem;
 
 #[cfg(not(feature = "no_std"))]
 use std::mem;

--- a/src/iterators/owning_iterator.rs
+++ b/src/iterators/owning_iterator.rs
@@ -61,7 +61,7 @@ impl<'a> Iterator for OwningIterator<'a> {
             // Since we cannot annotate the lifetime 'a to &mut self
             // because of the Iterator trait's signature, this seems
             // the only way to make the compiler happy.
-            // 
+            //
             // TODO: If you can make this work with safe Rust, please do.
             unsafe {
                 let ptr = &self.iterable[last_idx] as *const VertexId;
@@ -78,7 +78,11 @@ mod tests {
 
     #[test]
     fn it_yields_correct_vertex_ids() {
-        let ids: VecDeque<VertexId> = vec![VertexId::random(), VertexId::random(), VertexId::random()].iter().cloned().collect();
+        let ids: VecDeque<VertexId> =
+            vec![VertexId::random(), VertexId::random(), VertexId::random()]
+                .iter()
+                .cloned()
+                .collect();
         let mut iter = OwningIterator::new(ids.clone());
 
         assert_eq!(iter.next(), Some(&ids[0]));

--- a/src/iterators/topo.rs
+++ b/src/iterators/topo.rs
@@ -6,8 +6,6 @@ use crate::vertex_id::VertexId;
 use hashbrown::HashMap;
 
 #[cfg(feature = "no_std")]
-extern crate alloc;
-#[cfg(feature = "no_std")]
 use alloc::vec::Vec;
 
 #[cfg(feature = "no_std")]

--- a/src/iterators/vertices.rs
+++ b/src/iterators/vertices.rs
@@ -7,10 +7,10 @@ use core::fmt::Debug;
 extern crate alloc;
 #[cfg(feature = "no_std")]
 use alloc::boxed::Box;
-#[cfg(not(feature = "no_std"))]
-use std::fmt::Debug;
 #[cfg(feature = "no_std")]
 use core::fmt::Debug;
+#[cfg(not(feature = "no_std"))]
+use std::fmt::Debug;
 
 pub(crate) trait MergedTrait<'a>: Iterator<Item = &'a VertexId> + Debug {}
 

--- a/src/iterators/vertices.rs
+++ b/src/iterators/vertices.rs
@@ -7,8 +7,6 @@ use core::fmt::Debug;
 extern crate alloc;
 #[cfg(feature = "no_std")]
 use alloc::boxed::Box;
-#[cfg(feature = "no_std")]
-use core::fmt::Debug;
 #[cfg(not(feature = "no_std"))]
 use std::fmt::Debug;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,7 @@ pub(crate) fn gen_bytes() -> [u8; 16] {
         &mut IsaacRng::seed_from_u64(SEED.fetch_add(1, Ordering::Relaxed) as u64),
     )))
 }
+
+#[cfg(feature = "no_std")]
+#[macro_use]
+extern crate alloc;


### PR DESCRIPTION
It avoids reduntant code and expands before compilation, easier to manage this way + rustfmt