### PR TITLE
Improve labeling to support edges and use dot's labels instead of IDs

### DIFF
--- a/examples/dot.rs
+++ b/examples/dot.rs
@@ -16,12 +16,12 @@ pub fn main() {
 
     #[cfg(feature = "dot")]
     {
-        graph.label_vertex(&v1, "label: test1").unwrap();
-        graph.label_vertex(&v2, "label: test2").unwrap();
-        graph.label_vertex(&v3, "label: test3").unwrap();
-        graph.label_vertex(&v4, "label: test4").unwrap();
-        graph.label_vertex(&v5, "label: test5").unwrap();
-        graph.label_vertex(&v6, "label: test6").unwrap();
+        graph.add_vertex_label(&v1, "label: test1").unwrap();
+        graph.add_vertex_label(&v2, "label: test2").unwrap();
+        graph.add_vertex_label(&v3, "label: test3").unwrap();
+        graph.add_vertex_label(&v4, "label: test4").unwrap();
+        graph.add_vertex_label(&v5, "label: test5").unwrap();
+        graph.add_vertex_label(&v6, "label: test6").unwrap();
     }
 
     graph.add_edge(&v1, &v2).unwrap();

--- a/examples/dot.rs
+++ b/examples/dot.rs
@@ -30,5 +30,13 @@ pub fn main() {
     graph.add_edge(&v5, &v6).unwrap();
 
     #[cfg(feature = "dot")]
+    {
+        graph.add_edge_label(&v1, &v2, "V1&rarr;V2").unwrap();
+        graph.add_edge_label(&v3, &v1, "V3&rarr;V1").unwrap();
+        graph.add_edge_label(&v1, &v4, "V1&rarr;V4").unwrap();
+        graph.add_edge_label(&v5, &v6, "V5&rarr;V6").unwrap();
+    }
+
+    #[cfg(feature = "dot")]
     graph.to_dot("example1", &mut f).unwrap();
 }

--- a/examples/dot.rs
+++ b/examples/dot.rs
@@ -16,12 +16,12 @@ pub fn main() {
 
     #[cfg(feature = "dot")]
     {
-        graph.label_vertex(&v1, "test1").unwrap();
-        graph.label_vertex(&v2, "test2").unwrap();
-        graph.label_vertex(&v3, "test3").unwrap();
-        graph.label_vertex(&v4, "test4").unwrap();
-        graph.label_vertex(&v5, "test5").unwrap();
-        graph.label_vertex(&v6, "test6").unwrap();
+        graph.label_vertex(&v1, "label: test1").unwrap();
+        graph.label_vertex(&v2, "label: test2").unwrap();
+        graph.label_vertex(&v3, "label: test3").unwrap();
+        graph.label_vertex(&v4, "label: test4").unwrap();
+        graph.label_vertex(&v5, "label: test5").unwrap();
+        graph.label_vertex(&v6, "label: test6").unwrap();
     }
 
     graph.add_edge(&v1, &v2).unwrap();

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -53,6 +53,13 @@ impl<'a, T> dot::Labeller<'a, Nd, Ed<'a>> for DotGraph<'a, T> {
             .unwrap_or_else(|| String::new());
         dot::LabelText::label(Cow::Owned(label))
     }
+
+    fn edge_label<'b>(&'b self, e: &Ed) -> dot::LabelText<'b> {
+        let label = self.graph.edge_label(e.0, e.1)
+            .cloned()
+            .unwrap_or_else(|| String::new());
+        dot::LabelText::LabelStr(Cow::Owned(label))
+    }
 }
 
 
@@ -63,7 +70,9 @@ impl<'a, T> dot::GraphWalk<'a, Nd, Ed<'a>> for DotGraph<'a, T> {
     }
 
     fn edges(&'a self) -> dot::Edges<'a, Ed<'a>> {
-        self.graph.edges().collect()
+        self.graph.edges()
+            .map(|e| (e.1, e.0))
+            .collect()
     }
 
     fn source(&self, e: &Ed) -> Nd {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -48,17 +48,13 @@ impl<'a, T> dot::Labeller<'a, Nd, Ed<'a>> for DotGraph<'a, T> {
     }
 
     fn node_label<'b>(&'b self, n: &Nd) -> dot::LabelText<'b> {
-        let label = self.graph.vertex_label(n)
-            .cloned()
-            .unwrap_or_else(|| String::new());
-        dot::LabelText::label(Cow::Owned(label))
+        let label = self.graph.vertex_label(n).unwrap();
+        dot::LabelText::label(Cow::Borrowed(label))
     }
 
     fn edge_label<'b>(&'b self, e: &Ed) -> dot::LabelText<'b> {
-        let label = self.graph.edge_label(e.0, e.1)
-            .cloned()
-            .unwrap_or_else(|| String::new());
-        dot::LabelText::LabelStr(Cow::Owned(label))
+        let label = self.graph.edge_label(e.0, e.1).unwrap();
+        dot::LabelText::LabelStr(Cow::Borrowed(label))
     }
 }
 

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,5 +1,4 @@
-use crate::graph::Graph;
-use crate::graph::GraphErr;
+use crate::{Graph, GraphErr, VertexId};
 
 #[cfg(feature = "no_std")]
 use core::io::Write;
@@ -19,61 +18,59 @@ use core::fmt::Debug;
 #[cfg(not(feature = "no_std"))]
 use std::fmt::Debug;
 
-/*
-Bounds on types throw warnings
-type Nd<D: Clone + Debug> = D;
-type Ed<D: Clone + Debug> = (D, D);
-*/
-type Nd = String;
-type Ed = (String, String);
+type Nd = VertexId;
+type Ed<'a> = (&'a VertexId, &'a VertexId);
 
-pub(crate) struct Edges<'a> {
-    pub(crate) edges: Vec<Ed>,
-    pub(crate) graph_name: dot::Id<'a>,
+
+pub(crate) struct DotGraph<'a, T> {
+    name: dot::Id<'a>,
+    graph: &'a Graph<T>,
 }
 
-impl<'a> Edges<'a> {
-    pub fn new(edges: Vec<Ed>, graph_name: &'a str) -> Result<Edges<'a>, GraphErr> {
-        let graph_name = dot::Id::new(graph_name).map_err(|_| GraphErr::InvalidGraphName)?;
 
-        Ok(Edges { edges, graph_name })
+impl<'a, T> DotGraph<'a, T> {
+    pub fn new(graph: &'a Graph<T>, name: &'a str) -> Result<DotGraph<'a, T>, GraphErr> {
+        let name = dot::Id::new(name)
+            .map_err(|_| GraphErr::InvalidGraphName)?;
+        Ok(DotGraph { name, graph })
     }
 }
 
-impl<'a> dot::Labeller<'a, Nd, Ed> for Edges<'a> {
-    fn graph_id(&'a self) -> dot::Id {
-        dot::Id::new(self.graph_name.as_slice()).unwrap()
+
+impl<'a, T> dot::Labeller<'a, Nd, Ed<'a>> for DotGraph<'a, T> {
+    fn graph_id(&'a self) -> dot::Id<'a> {
+        dot::Id::new(self.name.as_slice()).unwrap()
     }
 
-    fn node_id(&'a self, n: &Nd) -> dot::Id {
-        dot::Id::new(n.clone()).unwrap()
+    fn node_id(&'a self, n: &Nd) -> dot::Id<'a> {
+        let hex = format!("N{}", hex::encode(n.bytes()));
+        dot::Id::new(hex).unwrap()
+    }
+
+    fn node_label<'b>(&'b self, n: &Nd) -> dot::LabelText<'b> {
+        let label = self.graph.label(n)
+            .unwrap_or_else(|| String::new());
+        dot::LabelText::label(Cow::Owned(label))
     }
 }
 
-impl<'a> dot::GraphWalk<'a, Nd, Ed> for Edges<'a> {
+
+impl<'a, T> dot::GraphWalk<'a, Nd, Ed<'a>> for DotGraph<'a, T> {
     fn nodes(&self) -> dot::Nodes<'a, Nd> {
-        let &Edges { edges: ref v, .. } = self;
-        let mut nodes = Vec::with_capacity(v.len());
-
-        for (s, t) in v.iter() {
-            nodes.push(s.clone());
-            nodes.push(t.clone());
-        }
-
+        let nodes = self.graph.vertices().cloned().collect();
         Cow::Owned(nodes)
     }
 
-    fn edges(&'a self) -> dot::Edges<'a, Ed> {
-        let &Edges {
-            edges: ref edges, ..
-        } = self;
-        Cow::Borrowed(&edges[..])
+    fn edges(&'a self) -> dot::Edges<'a, Ed<'a>> {
+        self.graph.edges().collect()
     }
 
     fn source(&self, e: &Ed) -> Nd {
-        e.0.clone()
+        *e.0
     }
+
     fn target(&self, e: &Ed) -> Nd {
-        e.1.clone()
+        *e.1
     }
 }
+

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -48,7 +48,8 @@ impl<'a, T> dot::Labeller<'a, Nd, Ed<'a>> for DotGraph<'a, T> {
     }
 
     fn node_label<'b>(&'b self, n: &Nd) -> dot::LabelText<'b> {
-        let label = self.graph.label(n)
+        let label = self.graph.vertex_label(n)
+            .cloned()
             .unwrap_or_else(|| String::new());
         dot::LabelText::label(Cow::Owned(label))
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -17,8 +17,6 @@ use std::fmt::Debug;
 
 #[cfg(feature = "no_std")]
 use core::mem;
-#[cfg(not(feature = "no_std"))]
-use std::mem;
 
 #[cfg(feature = "no_std")]
 extern crate alloc;
@@ -90,6 +88,8 @@ pub struct Graph<T> {
     /// Mapping between edges and labels
     edge_labels: HashMap<Edge, String>,
 }
+
+const DEFAULT_LABEL: &str = "";
 
 impl<T> Graph<T> {
     /// Creates a new graph.
@@ -1437,8 +1437,14 @@ impl<T> Graph<T> {
     /// This method requires the `dot` crate feature.
     ///
     /// Returns `None` if there is no vertex associated with the given id in the graph.
-    pub fn vertex_label(&self, vertex_id: &VertexId) -> Option<&String> {
+    pub fn vertex_label(&self, vertex_id: &VertexId) -> Option<&str> {
+        if !self.vertices.contains_key(vertex_id) {
+            return None;
+        }
+
         self.vertex_labels.get(vertex_id)
+            .map(|x| x.as_str())
+            .or(Some(&DEFAULT_LABEL))
     }
 
     #[cfg(feature = "dot")]
@@ -1447,8 +1453,14 @@ impl<T> Graph<T> {
     /// This method requires the `dot` crate feature.
     ///
     /// Returns `None` if there is no edge associated with the given vertices in the graph.
-    pub fn edge_label(&self, a: &VertexId, b: &VertexId) -> Option<&String> {
+    pub fn edge_label(&self, a: &VertexId, b: &VertexId) -> Option<&str> {
+        if !self.has_edge(a, b) {
+            return None;
+        }
+
         self.edge_labels.get(&Edge::new(*a, *b))
+            .map(|x| x.as_str())
+            .or(Some(&DEFAULT_LABEL))
     }
 
     #[cfg(feature = "dot")]

--- a/src/vertex_id.rs
+++ b/src/vertex_id.rs
@@ -20,4 +20,8 @@ impl VertexId {
     pub fn random() -> VertexId {
         VertexId(super::gen_bytes())
     }
+
+    pub fn bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
 }


### PR DESCRIPTION
The current dot implementation from #13  is overly restrictive about which strings are allowed for labels, returning an [`InvalidLabel`](https://docs.rs/graphlib/0.6.2/graphlib/enum.GraphErr.html#variant.InvalidLabel) Err in many cases where the label should be allowed (e.g. even just by having a space in the label).

This is caused by incorrectly using [dot::Id](https://docs.rs/dot/0.1.4/dot/struct.Id.html)/ [`node_id()`](https://docs.rs/dot/0.1.4/dot/trait.Labeller.html#tymethod.node_id) for labels and not just for node IDs.

In this pull request I made the following changes:

* Made labels less restrictive by implementing [`node_label()`](https://docs.rs/dot/0.1.4/dot/trait.Labeller.html#method.node_label) which uses [`dot::LabelText`](https://docs.rs/dot/0.1.4/dot/enum.LabelText.html) instead of `dot::Id`
* Added support for edge labelling
    * After doing this, I found the naming a bit confusing: `label_vertex()` (set), `vertex_label()` (get), `label_edge()` (set), `edge_label()` (get)
    * I think the naming `add_vertex_label()` (set), `vertex_label()` (get) is clearer
* Restructured the dot integration to be based on the `Graph` itself. This is a more extensible approach, and since [dot::Labeller](https://docs.rs/dot/0.1.4/dot/trait.Labeller.html) supports many other features (e.g. `node_color()`) it's possible additional data from the graph will be needed in the future

I ran the example:

```sh
$ cargo run --example dot --features dot
$ dot -Tpdf example1.dot -o example1.pdf
```

Which produces the following result

> ![screenshot-graphlib](https://user-images.githubusercontent.com/11810057/84827191-618a8280-b024-11ea-99c2-610a451ad9e1.png)
