### PR TITLE
Improve graphlib::iterators::Dijkstra API

### DIFF
--- a/src/iterators/dijkstra.rs
+++ b/src/iterators/dijkstra.rs
@@ -52,7 +52,6 @@ impl Ord for VertexMeta {
 pub struct Dijkstra<'a, T> {
     source: &'a VertexId,
     iterable: &'a Graph<T>,
-    iterator: VecDeque<VertexId>,
     distances: HashMap<VertexId, f32>,
     previous: HashMap<VertexId, Option<VertexId>>,
 }
@@ -74,7 +73,6 @@ impl<'a, T> Dijkstra<'a, T> {
         let mut instance = Dijkstra {
             source: src,
             iterable: graph,
-            iterator: VecDeque::with_capacity(graph.vertex_count()),
             distances: HashMap::with_capacity(graph.vertex_count()),
             previous: HashMap::with_capacity(graph.vertex_count()),
         };
@@ -97,25 +95,25 @@ impl<'a, T> Dijkstra<'a, T> {
         Ok(())
     }
 
-    pub fn get_path_to(mut self, vert: &'a VertexId) -> Result<VertexIter, GraphErr> {
+    pub fn get_path_to(&self, vert: &'a VertexId) -> Result<VertexIter<'a>, GraphErr> {
         if self.iterable.fetch(vert).is_none() {
             return Err(GraphErr::NoSuchVertex);
         }
 
         if self.previous.contains_key(vert) {
             let mut cur_vert = Some(vert);
-            self.iterator.clear();
+            let mut iterator = VecDeque::new();
 
-            while cur_vert.is_some() {
-                self.iterator.push_front(*cur_vert.unwrap());
+            while let Some(cur_vert_inner) = cur_vert {
+                iterator.push_front(*cur_vert_inner);
 
-                match self.previous.get(cur_vert.unwrap()) {
+                match self.previous.get(cur_vert_inner) {
                     Some(v) => cur_vert = v.as_ref(),
                     None => cur_vert = None,
                 }
             }
 
-            return Ok(VertexIter(Box::new(OwningIterator::new(self.iterator))));
+            return Ok(VertexIter(Box::new(OwningIterator::new(iterator))));
         }
 
         Ok(VertexIter(Box::new(iter::empty())))

--- a/src/iterators/dijkstra.rs
+++ b/src/iterators/dijkstra.rs
@@ -119,16 +119,12 @@ impl<'a, T> Dijkstra<'a, T> {
         Ok(VertexIter(Box::new(iter::empty())))
     }
 
-    pub fn get_distance(&mut self, vert: &'a VertexId) -> Result<f32, GraphErr> {
+    pub fn get_distance(&self, vert: &'a VertexId) -> Result<f32, GraphErr> {
         if self.iterable.fetch(vert).is_none() {
             return Err(GraphErr::NoSuchVertex);
         }
 
-        if self.distances.contains_key(vert) {
-            return Ok(*self.distances.get(vert).unwrap());
-        }
-
-        Ok(f32::MAX)
+        Ok(self.distances.get(vert).copied().unwrap_or(f32::MAX))
     }
 
     fn calc_distances(&mut self) {


### PR DESCRIPTION
The `Dijkstra::new()` API computes the single-source shortest path between a given source and every other vertex in the graph.  For a consumer that cares about the shortest path between a given source and two or more other graph nodes (e.g., `A` → `B`, `A` → `C`, etc), the SSSP computation can be reused.  This is more efficient than recomputing it for every destination node (and part of why SSSP is a great algorithm).

These changes make reuse more ergonomic by not consuming the value, and referencing the `Dijkstra` object immutably rather than mutably.

Previously, one could reuse the results of the SSSP computation only by `clone()`ing the entire `Dijkstra` object, which is inefficient.

Tests continue to pass.